### PR TITLE
Fix: debian package sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dll
 *.so
 *.dylib
+pkgtop
 
 # Test binary, built with `go test -c`
 *.test

--- a/src/pkgtop.go
+++ b/src/pkgtop.go
@@ -101,6 +101,8 @@ var (
 		"   l/h, right/left         : Scroll down/up (disk usage)\n" +
 		"   backspace               : Go back\n" +
 		"   q, esc, ctrl-c, ctrl-d  : Exit\n"
+
+	osID string
 )
 
 /*!
@@ -212,6 +214,10 @@ func getPkgListEntries(pkgs []string) ([]*widgets.List,
 			}
 			/* Convert size to human readable format if possible. */
 			if size, err := strconv.ParseInt(str.Split(pkg, ";")[i], 10, 64); err == nil && titles[i] == "Installed Size" {
+				// https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-installed-size
+				if osID == "debian,ubuntu,mint" {
+					size = size * 1024
+				}
 				rows = append(rows, " "+humanize.Bytes(uint64(size)))
 			} else {
 				rows = append(rows, " "+str.Split(pkg, ";")[i])
@@ -288,7 +294,7 @@ func execCmd(name string, arg ...string) string {
  * \param osID (Operating system identity)
  * \return 0 on exit
  */
-func start(osID string) int {
+func start(osid string) int {
 	/* Initialize the termui library. */
 	if err := ui.Init(); err != nil {
 		log.Fatalf("Failed to initialize termui: %v", err)
@@ -322,7 +328,7 @@ func start(osID string) int {
 	pkgText.BorderStyle.Fg = ui.ColorBlack
 	sysInfoText.BorderStyle.Fg = ui.ColorBlack
 	/* Set the operating system variable. */
-	osID = str.ToLower(str.TrimSpace(str.Split(osID, "\n")[0]))
+	osID = str.ToLower(str.TrimSpace(str.Split(osid, "\n")[0]))
 OSCheckLoop:
 	for ids := range pkgsCmd {
 		for _, id := range str.Split(ids, ",") {

--- a/src/pkgtop.go
+++ b/src/pkgtop.go
@@ -291,7 +291,7 @@ func execCmd(name string, arg ...string) string {
 /*!
  * Initialize, execute, render and handle.
  *
- * \param osID (Operating system identity)
+ * \param osid (Operating system identity)
  * \return 0 on exit
  */
 func start(osid string) int {


### PR DESCRIPTION
### [5.6.20. Installed-Size](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-installed-size)

This field appears in the control files of binary packages, and in the Packages files. It gives an estimate of the total amount of disk space required to install the named package. Actual installed size may vary based on block size, file system properties, or actions taken by package maintainer scripts.

**The disk space is given as the integer value of the estimated installed size in bytes, divided by 1024 and rounded up**.